### PR TITLE
Switch billing address fields on/off based on gateway option

### DIFF
--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -138,11 +138,16 @@ function pmproappe_pmpro_checkout_boxes()
 	?>
 	<script>
 		var pmpro_require_billing = <?php if($pmpro_requirebilling) echo "true"; else echo "false";?>;
+        var pmpro_paypal_billingaddress = <?php if ( pmpro_getOption( "paypal_billingaddress" ) ) echo "true"; else echo "false";?>;
 
-		//hide/show functions
-		function showPayPalExpressCheckout()
-		{
-			jQuery('#pmpro_billing_address_fields').hide();
+        //hide/show functions
+        function showPayPalExpressCheckout() {
+            if (!pmpro_paypal_billingaddress) {
+                jQuery('#pmpro_billing_address_fields').hide();
+            } else {
+                jQuery('#pmpro_billing_address_fields').show();
+            }
+
 			jQuery('#pmpro_payment_information_fields').hide();
 			jQuery('#pmpro_submit_span').hide();
 			jQuery('#pmpro_paypalexpress_checkout').show();
@@ -281,7 +286,12 @@ function pmproappe_pmpro_applydiscountcode_return_js($discount_code, $discount_c
 		}
 		else if(pmpro_require_billing == true)
 		{
-			jQuery('#pmpro_billing_address_fields').hide();
+            if (!pmpro_paypal_billingaddress) {
+                jQuery('#pmpro_billing_address_fields').hide();
+            } else {
+                jQuery('#pmpro_billing_address_fields').show();
+            }
+
 			jQuery('#pmpro_payment_information_fields').hide();
 			jQuery('#pmpro_submit_span').hide();
 			jQuery('#pmpro_paypalexpress_checkout').show();


### PR DESCRIPTION
Adds support to the [New "Show Billing Address Fields" option for PayPal Express](https://github.com/strangerstudios/paid-memberships-pro/pull/2004).

This makes possible to have Stripe + PayPal Express in various configurations:
1. Never show address fields (Stripe No, PPE No)
1. Stripe shows address fields, PPE does not (Stripe Yes, PPE No)
1. Always show address fields (Stripe Yes, PPE Yes) => except free levels. Should use "Address For Free Levels Add On" to have address fields for free levels too.

**The only not supported configuration is "Stripe No, PPE Yes".** This is not possible at this point because when Stripe does not activate the billing address fields, they are just not part of the dom. This would require a different approach, maybe in the future.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you extensively run tests on a complex environment?

I want to make tests on my complex env with:
- Free levels (no billing fields)
- Stripe: primary payment method
- PPE: secondary with Add PayPal Express Add On

