### PR TITLE
Remove features when PayPal is the primary payment method

### DIFF
--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -335,6 +335,12 @@ add_action('admin_notices', 'pmproappe_admin_notices');
 	The JS in this Add On will then hide/show the fields based on which gateway option is chosen.
 */
 function pmproappe_include_billing_and_payment_fields() {
+	//if already using paypal, ignore this
+	$setting_gateway = get_option("pmpro_gateway");
+	if(pmproappe_using_paypal( $setting_gateway )) {
+		return;
+	}
+
 	global $gateway;
 		
 	if ( $gateway == 'paypalexpress' ) {

--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -34,22 +34,26 @@ function pmpro_add_paypal_express_register_styles() {
 }
 add_action( 'wp_enqueue_scripts', 'pmpro_add_paypal_express_register_styles' );
 
-/*
-	Make PayPal Express a valid gateway.
-*/
-function pmproappe_pmpro_valid_gateways($gateways)
-{
-    //if already using paypal, ignore this
-	$setting_gateway = get_option("pmpro_gateway");
+/**
+ * Make PayPal Express a valid gateway.
+ *
+ * @param array $gateways Array of valid gateways.
+ */
+function pmproappe_pmpro_valid_gateways( $gateways ) {
+	// Get the current gateway setting.
+	$setting_gateway = get_option( 'pmpro_gateway' );
 
-	if(pmproappe_using_paypal( $setting_gateway )) {
+	// If PayPal is already the current gateway, ignore this.
+	if ( pmproappe_using_paypal( $setting_gateway ) ) {
 		return $gateways;
 	}
 
+	// Add PayPal Express to the list of valid gateways.
 	$gateways[] = "paypalexpress";
-    return $gateways;
+
+	return $gateways;
 }
-add_filter("pmpro_valid_gateways", "pmproappe_pmpro_valid_gateways");
+add_filter( 'pmpro_valid_gateways', 'pmproappe_pmpro_valid_gateways' );
 
 /*
 	Check if a PayPal gateway is enabled for PMPro.


### PR DESCRIPTION
There's an issue when you have PPE as primary payment method and you activate this Add On.
The billing address fields + the credit card fields show up.

This is an unwanted behaviour and doesn't make any sense.
Of course having this setup doesn't make any sense too, but sometimes you just forget to have that addon installed.

Resolves #14.

**Another approach is to make a preliminary check on the gateway option.
Then, if requirements are good, hook everything in.**