### PR TITLE
Updating headings hierarchy to match new PMPro checkout page for a11y

### DIFF
--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -89,9 +89,9 @@ function pmproappe_pmpro_checkout_boxes()
 	?>
 	<div id="pmpro_payment_method" class="pmpro_checkout" <?php if(!$pmpro_requirebilling) { ?>style="display: none;"<?php } ?>>
 		<hr />
-		<h3>
-			<span class="pmpro_checkout-h3-name"><?php _e('Choose Your Payment Method', 'pmpro-add-paypal-express');?></span>
-		</h3>
+		<h2>
+			<span class="pmpro_checkout-h2-name"><?php _e('Choose Your Payment Method', 'pmpro-add-paypal-express');?></span>
+		</h2>
 		<div class="pmpro_checkout-fields">
 			<?php if($setting_gateway != 'check') { ?>
 			<span class="gateway_<?php echo esc_attr($setting_gateway); ?>">


### PR DESCRIPTION
PMPro v2.11 updated the checkout page headings hierarchy from h3 to h2. This PR updates this Add On to follow the same pattern for accessibility.