### PR TITLE
Updating the plugin to work with PayPal Standard and PayPal WPP

### DIFF
--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -65,7 +65,7 @@ function pmproappe_using_paypal( $check_gateway = null ) {
 		$check_gateway = $gateway;
 	}
 
-	$paypal_gateways = apply_filters('pmpro_paypal_gateways', array('paypal', 'paypalstandard', 'paypalexpress' ) );
+	$paypal_gateways = apply_filters('pmpro_paypal_gateways', array( 'paypalexpress' ) );
 
 	if ( in_array($check_gateway, $paypal_gateways)) {
 		return true;
@@ -346,7 +346,7 @@ function pmproappe_admin_notices() {
 	if( !empty( $_REQUEST['page'] ) && $_REQUEST['page'] == 'pmpro-paymentsettings' ) {
 		//check gateway
 		$gateway = pmpro_getGateway();
-		if( $gateway == 'paypal' || $gateway == 'paypalexpress' ) {
+		if( $gateway == 'paypalexpress' ) {
 		?>
 		<div class="notice notice-warning is-dismissible">
 			<p><?php echo __( 'The Add PayPal Express Add On is not required with the chosen gateway. Change the gateway setting below or deactivate the Add On.', 'pmpro-add-paypal-express' ) ;?></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-add-paypal-express/blob/dev/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-add-paypal-express/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updating the plugin to work with PayPal Standard and PayPal Website Payments Pro.

This PR should only be merged and released once PMPro v3.2 is launched. That update is when PPE will no longer be automatically bundled as a second option with PayPal WPP.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
