### PR TITLE
Remove the word "Here" from checkout message

### DIFF
--- a/pmpro-add-paypal-express.php
+++ b/pmpro-add-paypal-express.php
@@ -105,7 +105,7 @@ function pmproappe_pmpro_checkout_boxes()
 								<div class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_field pmpro_form_field-radio-item' ) ); ?> gateway_<?php echo esc_attr($setting_gateway); ?>">
 									<input type="radio" id="gateway_<?php echo esc_attr( $setting_gateway ); ?>" name="gateway" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_input pmpro_form_input-radio' ) ); ?>" value="<?php echo esc_attr( $setting_gateway ); ?>" <?php if(!$gateway || $gateway == $setting_gateway) { ?>checked="checked"<?php } ?> />
 									<label for="gateway_<?php echo esc_attr( $setting_gateway ); ?>" class="<?php echo esc_attr( pmpro_get_element_class( 'pmpro_form_label pmpro_form_label-inline pmpro_clickable' ) ); ?>">
-										<?php esc_html_e( 'Check Out with a Credit Card Here', 'pmpro-add-paypal-express' ); ?>
+										<?php esc_html_e( 'Check Out with a Credit Card', 'pmpro-add-paypal-express' ); ?>
 									</label>
 								</div> <!-- end pmpro_form_field pmpro_form_field-radio-item -->
 							<?php } ?>


### PR DESCRIPTION
Was Check Out with a Credit Card Here
Because Stripe Checkout is being used, the word "Here," is not relevant.

### All Submissions:

* [x ] Have you followed the [Contributing guidelines](https://github.com/strangerstudios/pmpro-add-paypal-express/blob/dev/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/strangerstudios/pmpro-add-paypal-express/pulls/) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Resolves XXX.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
